### PR TITLE
Change the `quote` function so the brackets don't go backwards

### DIFF
--- a/quoter.lua
+++ b/quoter.lua
@@ -26,8 +26,14 @@ function preRune(bp, r)
 	end
 end
 
-function quote(bp, open, close)
-	bp.Buf:Insert(-bp.Cursor.CurSelection[1], open)
-	bp.Buf:Insert(-bp.Cursor.CurSelection[2], close)
-	bp.Cursor.CurSelection[2].X = bp.Cursor.CurSelection[2].X -1
+function quote(bp, open, close)	
+	if not (-bp.Cursor.CurSelection[1]):GreaterThan(-bp.Cursor.CurSelection[2]) then -- is the first selection point later in the document than the second?
+		bp.Buf:Insert(-bp.Cursor.CurSelection[1], open)  -- right order
+		bp.Buf:Insert(-bp.Cursor.CurSelection[2], close) -- this happens almost always
+		bp.Cursor.CurSelection[2].X = bp.Cursor.CurSelection[2].X - 1
+	else
+		bp.Buf:Insert(-bp.Cursor.CurSelection[2], open)  -- backwards to make sure the brackets aren't )like this(
+		bp.Buf:Insert(-bp.Cursor.CurSelection[1], close) -- this only happens if the user selects text backwards with a mouse
+		bp.Cursor.CurSelection[1].X = bp.Cursor.CurSelection[1].X - 1
+	end
 end


### PR DESCRIPTION
This fixes [this issue](https://github.com/deusnefum/micro-quoter/issues/1). It changes the `quote` function so that when text is selected backwards with a mouse (maybe it only even happens in Terminal.app on macos) the brackets aren't the wrong way )like this(