### PR TITLE
Add angle brackets and backticks

### DIFF
--- a/quoter.lua
+++ b/quoter.lua
@@ -4,7 +4,7 @@ local config = import("micro/config")
 
 -- TODO: auto-indent when {} are used?
 
-local quotePairs = {{"\"", "\""}, {"'","'"}, {"`","`"}, {"(",")"}, {"{","}"}, {"[","]"}}
+local quotePairs = {{"\"", "\""}, {"'","'"}, {"`","`"}, {"(",")"}, {"{","}"}, {"[","]"}, {"<",">"}, {"`","`"}}
 
 function init()
 	config.RegisterCommonOption("quoter", "enable", true)


### PR DESCRIPTION
Added commonly used angle brackets (< >) and backticks (\` \`)

Thanks for the plugin it's very useful! one of the very few things micro is missing